### PR TITLE
Use git over https

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,9 +14,9 @@ let package = Package(
             targets: ["KeyboardKit"])
     ],
     dependencies: [
-        .package(url: "git@github.com:Quick/Quick.git", from: "2.2.0"),
-        .package(url: "git@github.com:Quick/Nimble.git", .exact("8.0.2")),
-        .package(url: "git@github.com:danielsaidi/Mockery.git", from: "0.1.1")
+        .package(url: "https://github.com/Quick/Quick.git", from: "2.2.0"),
+        .package(url: "https://github.com/Quick/Nimble.git", .exact("8.0.2")),
+        .package(url: "https://github.com/danielsaidi/Mockery.git", from: "0.1.1")
     ],
     targets: [
         .target(


### PR DESCRIPTION
Use https instead of git to avoid github authentication in xcode.