### PR TITLE
Update the demo to show emojis

### DIFF
--- a/KeyboardKitDemoKeyboard/Keyboards/DemoKeyboard.swift
+++ b/KeyboardKitDemoKeyboard/Keyboards/DemoKeyboard.swift
@@ -50,6 +50,6 @@ private extension Collection where Element == KeyboardAction {
 private extension KeyboardType {
 
     var shouldIncludeImageAction: Bool {
-        self == .emojis || self == .images
+        self != .emojis
     }
 }


### PR DESCRIPTION
Hi @danielsaidi 
Thanks for your great repo.
After running and looking at your demo. I saw that in your current demo. We couldn't switch the keyboard to show emojis. Then I dived to the code and found out that:
`var shouldIncludeImageAction: Bool {
        self == .emojis || self == .images
    }`
With your current code. It only returns true when you're in emojis or images  👯 => We never see the emojis in your demo. 
It should be
`var shouldIncludeImageAction: Bool {
        self != .emojis
    }`
So that in the alphabetic/numeric/etc... We could have the emojis as an option.

Finally, please correct me if there is something wrong.