### PR TITLE
change return key for backspace on emoji keyboard

### DIFF
--- a/KeyboardKitDemoKeyboard/Keyboards/DemoKeyboard.swift
+++ b/KeyboardKitDemoKeyboard/Keyboards/DemoKeyboard.swift
@@ -24,6 +24,11 @@ extension DemoKeyboard {
         let includeImageAction = vc.keyboardType.shouldIncludeImageAction
         return includeImageAction ? actions : actions.withoutImageActions
     }
+    static func bottomActionsEmoji(leftmost: KeyboardAction, for vc: KeyboardViewController) -> KeyboardActionRow {
+        let actions = [leftmost, switchAction(for: vc), .space, imageAction(for: vc), .backspace]
+        let includeImageAction = vc.keyboardType.shouldIncludeImageAction
+        return includeImageAction ? actions : actions.withoutImageActions
+    }
 }
 
 private extension DemoKeyboard {

--- a/KeyboardKitDemoKeyboard/Keyboards/EmojiKeyboard.swift
+++ b/KeyboardKitDemoKeyboard/Keyboards/EmojiKeyboard.swift
@@ -24,7 +24,7 @@ import KeyboardKit
 struct EmojiKeyboard: DemoKeyboard {
     
     init(in viewController: KeyboardViewController) {
-        self.bottomActions = EmojiKeyboard.bottomActions(
+        self.bottomActions = EmojiKeyboard.bottomActionsEmoji(
             leftmost: EmojiKeyboard.switchAction,
             for: viewController)
     }


### PR DESCRIPTION
Hi @danielsaidi thanks for your great keyboard.
in this pr change the "return" key to "backspace" as it currently has the keyboard of the iphone