### PR TITLE
Let clients customize how keyboard button rows are prepared

### DIFF
--- a/Sources/KeyboardKit/UIKit/KeyboardButtonRowCollectionView.swift
+++ b/Sources/KeyboardKit/UIKit/KeyboardButtonRowCollectionView.swift
@@ -123,9 +123,12 @@ open class KeyboardButtonRowCollectionView: KeyboardCollectionView, PagedKeyboar
     
     public let id: String
     public let configuration: Configuration
-    public private(set) var rows: KeyboardActionRows
     
-    public override var actions: [KeyboardAction] {
+    // This is public, and `actions` is open, so that you may choose to create
+    // rows from actions in a different way than this class does.
+    public var rows: KeyboardActionRows
+    
+    open override var actions: [KeyboardAction] {
         didSet { rows = actions.rows(for: configuration) }
     }
     


### PR DESCRIPTION
The stock emoji keyboard (collection view) is paginated. The emojis on the last
page are made a complete page (for purposes of scrolling fully onto that last
page) by inserting `KeyboardAction.none` placeholders into the action grid:

<img height="500" alt="Screen Shot 2020-05-24 at 7 19 34 PM" src="https://user-images.githubusercontent.com/110000/82772776-16020180-9df5-11ea-805a-c4290f084b3d.png">

If a client wishes to disable pagination in their own emoji keyboard, the user
will be able to seemingly “overscroll” the final emojis—where really, they were 
scrolling these invisible placeholders into view.

By opening `KeyboardButtonRowCollectionView#actions` to overrides and
making `rows`’ setter public, the client may subclass
`KeyboardButtonRowCollectionView` and create their own `rows` in
`actions#didSet`—in which they might, for instance, trim the extra
placeholders from the rows.