### PR TITLE
Minimal support for a “frequently used” emoji category

### DIFF
--- a/KeyboardKitDemoKeyboard/Buttons/DemoButton.swift
+++ b/KeyboardKitDemoKeyboard/Buttons/DemoButton.swift
@@ -88,6 +88,7 @@ private extension KeyboardAction {
     
     func buttonText(for category: EmojiCategory) -> String {
         switch category {
+        case .frequents: return "🕓"
         case .smileys: return "😀"
         case .animals: return "🐻"
         case .foods: return "🍔"

--- a/KeyboardKitDemoKeyboard/Localization/EmojiCategory+L10n.swift
+++ b/KeyboardKitDemoKeyboard/Localization/EmojiCategory+L10n.swift
@@ -5,6 +5,7 @@ extension EmojiCategory {
     
     var title: String {
         switch self {
+        case .frequents: return "FREQUENTLY USED"
         case .smileys: return "SMILEYS & PEOPLE"
         case .animals: return "ANIMALS & NATURE"
         case .foods: return "FOODS & DRINKS"

--- a/Sources/KeyboardKit/Emojis/EmojiCategory.swift
+++ b/Sources/KeyboardKit/Emojis/EmojiCategory.swift
@@ -15,6 +15,7 @@ import UIKit
 public enum EmojiCategory: Equatable, CaseIterable {
 
     case
+    frequents,
     smileys,
     animals,
     foods,
@@ -37,6 +38,10 @@ public extension EmojiCategory {
      */
     var emojis: [String] {
         switch self {
+        case .frequents:
+            // Clients are responsible for their own implementation of this
+            // category.
+            return []
         case .smileys: return smileys
         case .animals: return animals
         case .foods: return foods


### PR DESCRIPTION
This is a minimal version of #91 where storing the emojis is left to the client. I put this together because, in my emoji search keyboard, I derive the recent emojis from the system that powers my search results and wouldn't want the framework to try to store them separately.

With that said, it looks like most of the changes in #91 are in the demo app and the only change that references `UserDefaults` in the framework itself is just about [trying to read](https://github.com/danielsaidi/KeyboardKit/pull/91/files#diff-c5a7e45698b13533a2bcdcc794467c15R68) the emojis, not write them&mdash;so if you would like to merge #91 instead, that's totally fine by me.