### PR TITLE
Tweak shadows closer to native ones

### DIFF
--- a/KeyboardKitDemoKeyboard/Buttons/DemoButton.swift
+++ b/KeyboardKitDemoKeyboard/Buttons/DemoButton.swift
@@ -26,7 +26,16 @@ class DemoButton: KeyboardButtonView {
         textLabel?.textColor = action.tintColor(in: viewController)
         buttonView?.tintColor = action.tintColor(in: viewController)
         width = action.buttonWidth(for: distribution)
-        applyShadow(.standardButtonShadow)
+        useDark = action.useDarkAppearance(in: viewController)
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        if useDark {
+            buttonView?.applyShadow(.standardButtonShadowDark)
+        } else {
+            buttonView?.applyShadow(.standardButtonShadowLight)
+        }
     }
     
     @IBOutlet weak var buttonView: UIView? {
@@ -38,6 +47,8 @@ class DemoButton: KeyboardButtonView {
     @IBOutlet weak var textLabel: UILabel? {
         didSet { textLabel?.text = "" }
     }
+    
+    var useDark: Bool = false
 }
 
 

--- a/Sources/KeyboardKit/UIKit/Shadow/Shadow.swift
+++ b/Sources/KeyboardKit/UIKit/Shadow/Shadow.swift
@@ -40,6 +40,14 @@ public struct Shadow {
      The standard button shadow that replicates the iOS one.
      */
     public static var standardButtonShadow: Shadow {
-        Shadow(alpha: 0.5, blur: 0.5, spread: 0, x: 0, y: 1)
+        Shadow(alpha: 0.5, blur: 0.0, spread: 0, x: 0, y: 1)
+    }
+
+    public static var standardButtonShadowDark: Shadow {
+        Shadow(alpha: 0.5, blur: 0.0, spread: 0, x: 0, y: 1)
+    }
+
+    public static var standardButtonShadowLight: Shadow {
+        Shadow(alpha: 0.35, blur: 0.0, spread: 0, x: 0, y: 1)
     }
 }

--- a/Sources/KeyboardKit/UIKit/Shadow/UIView+Shadow.swift
+++ b/Sources/KeyboardKit/UIKit/Shadow/UIView+Shadow.swift
@@ -33,18 +33,17 @@ private extension CALayer {
         y: CGFloat = 2,
         blur: CGFloat = 4,
         spread: CGFloat = 0) {
+        masksToBounds = false
         shadowColor = color.cgColor
         shadowOpacity = alpha
-        shadowOffset = CGSize(width: x, height: y)
+        shadowOffset = CGSize(width: 0, height: 0)
         shadowRadius = blur / 2.0
+        let rect = bounds.insetBy(dx: -spread, dy: -spread)
+        let path = UIBezierPath(roundedRect: rect.offsetBy(dx: x, dy: y), cornerRadius: cornerRadius + spread)
+        path.append(UIBezierPath(roundedRect: bounds.inset(by: UIEdgeInsets(top: y, left: 0, bottom: 0, right: 0)), cornerRadius: cornerRadius).reversing())
+        shadowPath = path.cgPath
         shouldRasterize = true
         rasterizationScale = UIScreen.main.scale
-        if spread == 0 {
-            shadowPath = nil
-        } else {
-            let dx = -spread
-            let rect = bounds.insetBy(dx: dx, dy: dx)
-            shadowPath = UIBezierPath(rect: rect).cgPath
-        }
+        contentsScale = UIScreen.main.scale
     }
 }


### PR DESCRIPTION
I left the standard shadow as well, to remain backwards compatible. I had to move the shadow to the buttonView itself, and into the `layoutSubviews` call since it gets messed up when getting resized, and added a `useDark` variable as well, since the VC isn't accessible outside of the setup. If there's a better way of accomplishing this, please let me know!