### PR TITLE
Make emoji keyboard behave like more like the system one

### DIFF
--- a/KeyboardKitDemoKeyboard/DemoKeyboardActionHandler.swift
+++ b/KeyboardKitDemoKeyboard/DemoKeyboardActionHandler.swift
@@ -33,12 +33,8 @@ private extension DemoKeyboardActionHandler {
     func switchToEmojiKeyboardCategory(_ cat: EmojiCategory) {
         guard
             let vc = inputViewController as? KeyboardViewController,
-            let view = vc.emojiCollectionView,
-            let keyboard = vc.emojiKeyboard,
-            let index = keyboard.getPageIndex(for: cat)
+            let view = vc.emojiCollectionView
             else { return }
-        view.currentPageIndex = index
-        view.persistCurrentPageIndex()
-        vc.emojiCategoryTitleLabel.text = cat.title
+        view.moveToSection(byCategory: cat.title)
     }
 }

--- a/KeyboardKitDemoKeyboard/KeyboardViewController+Keyboard.swift
+++ b/KeyboardKitDemoKeyboard/KeyboardViewController+Keyboard.swift
@@ -31,19 +31,15 @@ extension KeyboardViewController {
     }
     
     func setupEmojiKeyboard() {
-        let keyboard = EmojiKeyboard(in: self)
+        let keyboard = EnhancedEmojiKeyboard(in: self)
         let config = keyboard.gridConfig
-        let view = KeyboardButtonRowCollectionView(id: "EmojiKeyboard", actions: keyboard.actions, configuration: config) { [unowned self] in return self.button(for: $0) }
+        let view = HFloatingHeaderButtonCollectionView(id: "EnhancedEmojiKeyboard", categoryActions: keyboard.categoryActions, configuration: config, buttonCreator: { [unowned self] in return self.button(for: $0) })
+        
         let bottom = buttonRow(for: keyboard.bottomActions, distribution: .fillProportionally)
-        let label = emojiCategoryTitleLabel
-        emojiLabelUpdateAction = { label.text = keyboard.getCategory(at: view.persistedCurrentPageIndex)?.title ?? "" }
-        view.panGestureRecognizer.addTarget(self, action: #selector(refreshEmojiCategoryLabel(_:)))
-        keyboardStackView.addArrangedSubview(emojiCategoryTitleLabel)
         keyboardStackView.addArrangedSubview(view)
         keyboardStackView.addArrangedSubview(bottom)
         emojiCollectionView = view
         emojiKeyboard = keyboard
-        emojiLabelUpdateAction()
     }
     
     func setupImageKeyboard() {

--- a/KeyboardKitDemoKeyboard/KeyboardViewController.swift
+++ b/KeyboardKitDemoKeyboard/KeyboardViewController.swift
@@ -89,10 +89,9 @@ class KeyboardViewController: KeyboardInputViewController {
     // MARK: - Properties
     
     let alerter = ToastAlert()
-    
-    var emojiKeyboard: EmojiKeyboard?
+    var emojiKeyboard: EnhancedEmojiKeyboard?
     var emojiCategoryTitleLabel = UILabel()
-    var emojiCollectionView: KeyboardButtonRowCollectionView!
+    var emojiCollectionView: HFloatingHeaderButtonCollectionView!
     var emojiLabelUpdateAction = {}
     
     

--- a/KeyboardKitDemoKeyboard/Keyboards/EnhancedEmojiKeyboard.swift
+++ b/KeyboardKitDemoKeyboard/Keyboards/EnhancedEmojiKeyboard.swift
@@ -1,0 +1,45 @@
+//
+//  CustomButtonRowCollectionView.swift
+//  KeyboardKitDemoKeyboard
+//
+//  Created by 于留传 on 2021/1/16.
+//
+
+import Foundation
+import UIKit
+import KeyboardKit
+
+struct EnhancedEmojiKeyboard: DemoKeyboard {
+    
+    init(in viewController: KeyboardViewController) {
+        let isLandscape = viewController.deviceOrientation.isLandscape
+        let rowsPerPage = isLandscape ? 3 : 5
+        gridConfig = HFloatingHeaderButtonCollectionView.Configuration(headerSize: CGSize(width: 200, height: 30), itemSize: CGSize(width: 48, height: 48), rowsCount: rowsPerPage, titleColor: nil, titleFont: nil, headerWidthToFitText: true, itemFont: UIFont.preferredFont(forTextStyle: .callout), itemWidthToFitText: true,  edgeInsets: .standardKeyboardRowItemInsets())
+        bottomActions = Self.createBottomActions(for: categories)
+        categoryActions = Self.createCategoryActions(for: categories)
+    }
+
+    let categoryActions: [(String, KeyboardActions)]
+    let bottomActions: KeyboardActionRow
+    let categories = EmojiCategory.all
+    let gridConfig: HFloatingHeaderButtonCollectionView.Configuration
+    
+    private var emoji: [KeyboardAction] = []
+}
+
+private extension EnhancedEmojiKeyboard {
+    
+    static func createBottomActions(for categories: [EmojiCategory]) -> KeyboardActionRow {
+        var actions = categories.map { KeyboardAction.emojiCategory($0) }
+        actions.insert(.keyboardType(.alphabetic(.lowercased)), at: 0)
+        actions.append(.backspace)
+        return actions
+    }
+    
+    static func createCategoryActions(for categories: [EmojiCategory]) -> [(String, KeyboardActions)]{
+        // Remove empty frequent
+        categories.filter { $0.rawValue != "frequent"}.compactMap {
+            ($0.title, $0.emojis.map{ KeyboardAction.emoji(String($0))})
+        }
+    }
+}

--- a/Sources/KeyboardKit/Layout/HorizontalFloatingHeaderLayout.swift
+++ b/Sources/KeyboardKit/Layout/HorizontalFloatingHeaderLayout.swift
@@ -1,0 +1,371 @@
+//
+//  HorizontalFloatingHeaderLayout.swift
+//
+//  Created by 于留传 on 2021/1/15.
+//
+
+// The following is copied from
+// https://github.com/tysonkerridge/HorizontalFloatingHeaderLayout/blob/master/Pod/Classes/HorizontalFloatingHeaderLayout.swift
+// And, make some change to be compilable.
+
+//
+//  HorizontalFloatingHeaderLayout.swift
+//  Pods
+//
+//  Created by Diego Alberto Cruz Castillo on 12/30/15.
+//
+//
+
+import UIKit
+
+@objc public protocol HorizontalFloatingHeaderLayoutDelegate: class {
+    
+    // Item size
+    func collectionView(_ collectionView: UICollectionView, horizontalFloatingHeaderItemSizeAt indexPath: IndexPath) -> CGSize
+    
+    // Header size
+    func collectionView(_ collectionView: UICollectionView, horizontalFloatingHeaderSizeAt section: Int) -> CGSize
+    
+    // Section Inset
+    @objc optional func collectionView(_ collectionView: UICollectionView, horizontalFloatingHeaderSectionInsetAt section: Int) -> UIEdgeInsets
+    
+    // Item Spacing
+    @objc optional func collectionView(_ collectionView: UICollectionView, horizontalFloatingHeaderItemSpacingForSectionAt section: Int) -> CGFloat
+    
+    // Line Spacing
+    @objc optional func collectionView(_ collectionView: UICollectionView, horizontalFloatingHeaderColumnSpacingForSectionAt section: Int) -> CGFloat
+    
+}
+
+public class HorizontalFloatingHeaderLayout: UICollectionViewLayout {
+    
+    
+    // MARK: - Properties
+    public override var collectionViewContentSize: CGSize {
+        get { return getContentSize() }
+    }
+    
+    
+    // MARK: Headers properties
+    
+    // Variables
+    private var sectionHeadersAttributes: [IndexPath : UICollectionViewLayoutAttributes] {
+        get { return getSectionHeadersAttributes() }
+    }
+    
+    
+    // MARK: Items properties
+    
+    // Variables
+    private var itemAttributes = [IndexPath : UICollectionViewLayoutAttributes]()
+    
+    
+    // MARK: - PrepareForLayout methods
+    
+    public override func prepare() {
+        prepareItemsAttributes()
+    }
+    
+    // Items
+    private func prepareItemsAttributes() {
+        
+        // Ensure we have a collection view else we have nothing to do
+        guard let collectionView = self.collectionView else { return }
+        
+        // Remove all current item attributes
+        itemAttributes.removeAll()
+        
+        // Get the number of sections we'll be displaying
+        let sectionCount = collectionView.numberOfSections
+        
+        // Ensure we have at least one section to prepare items for
+        guard sectionCount > 0 else { return }
+        
+        // Set up values to keep track of
+        var currentMinX: CGFloat = 0
+        var currentMinY: CGFloat = 0
+        var currentMaxX: CGFloat = 0
+        
+        // Work for configuring the values for each section
+        func configureVariables(forSection section: Int) {
+            let sectionInset = inset(ForSection: section)
+            let lastSectionInset = inset(ForSection: section - 1)
+            currentMinX = (currentMaxX + sectionInset.left + lastSectionInset.right)
+            currentMinY = sectionInset.top + headerSize(forSection: section).height
+            currentMaxX = 0.0
+        }
+        
+        // Work for creating the attributes for each item
+        func itemAttribute(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes {
+            
+            // Applying corrected layout
+            func newLineOrigin(size: CGSize) -> CGPoint {
+                let x = currentMaxX + columnSpacing(forSection: indexPath.section)
+                let y = inset(ForSection: indexPath.section).top + headerSize(forSection: indexPath.section).height
+                return CGPoint(x: x, y: y)
+            }
+            
+            func sameLineOrigin(size: CGSize) -> CGPoint {
+                return CGPoint(x: currentMinX, y: currentMinY)
+            }
+            
+            func updateVariables(itemFrame frame: CGRect) {
+                currentMaxX = max(currentMaxX, frame.maxX)
+                currentMinX = frame.minX
+                currentMinY = frame.maxY + itemSpacing(forSection: indexPath.section)
+            }
+            
+            //
+            let size = itemSize(for: indexPath)
+            let yFloatTolerance: CGFloat = 0.0001 // Float tolerance due to comparing equality of floats in relation to what will actually be displaid
+            let newMaxY = currentMinY + size.height
+            let origin: CGPoint
+            if (newMaxY - yFloatTolerance) > availableHeight(atSection: indexPath.section) {
+                origin = newLineOrigin(size: size)
+            } else {
+                origin = sameLineOrigin(size: size)
+            }
+            let frame = CGRect(origin: origin, size: size)
+            let attribute = UICollectionViewLayoutAttributes(forCellWith: indexPath)
+            attribute.frame = frame
+            updateVariables(itemFrame: frame)
+            return attribute
+        }
+        
+        // Create the attributes for the items in each section
+        for section in 0..<sectionCount {
+            
+            configureVariables(forSection: section)
+            let itemCount = collectionView.numberOfItems(inSection: section)
+            
+            // We're done if there's no items for this section
+            guard itemCount > 0 else { continue }
+            
+            // Create the attributes for each item
+            for index in 0..<itemCount {
+                let indexPath = IndexPath(row: index, section: section)
+                let attribute = itemAttribute(at: indexPath)
+                itemAttributes[indexPath] = attribute
+            }
+            
+        }
+        
+    }
+    
+    
+    // MARK: - LayoutAttributesForElementsInRect methods
+    
+    override public func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
+        
+        // Get the item & section attributes within the rect
+        let attributesAreWithinRect = { (attributes: UICollectionViewLayoutAttributes) in attributes.frame.intersects(rect) }
+        let itemsA = itemAttributes.values.filter(attributesAreWithinRect)
+        let headersA = sectionHeadersAttributes.values.filter(attributesAreWithinRect)
+        return itemsA + headersA
+    }
+    
+    //MARK: - ContentSize methods
+    private func getContentSize() -> CGSize {
+        
+        guard let collectionView = collectionView else {
+            return CGSize.zero
+        }
+        
+        func lastItemMaxX() -> CGFloat {
+            let lastSection = collectionView.numberOfSections - 1
+            guard lastSection >= 0 else { return 0 }
+            let lastIndexInSection = collectionView.numberOfItems(inSection: lastSection) - 1
+            if let lastItemAttributes = layoutAttributesForItem(at: IndexPath(row: lastIndexInSection, section: lastSection)) {
+                return lastItemAttributes.frame.maxX
+            } else {
+                return 0
+            }
+        }
+        
+        //
+        let lastSection = collectionView.numberOfSections - 1
+        let contentWidth = lastItemMaxX() + inset(ForSection: lastSection).right
+        let safeAreaInsets: UIEdgeInsets = { if #available(iOS 11.0, *) { return collectionView.safeAreaInsets } else { return .zero } }()
+        let contentHeight = collectionView.bounds.height - collectionView.contentInset.top - collectionView.contentInset.bottom - safeAreaInsets.top - safeAreaInsets.bottom
+        return CGSize(width: contentWidth, height: contentHeight)
+        
+    }
+    
+    
+    // MARK: - LayoutAttributes methods
+    
+    // MARK: For ItemAtIndexPath
+    
+    public override func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
+        return itemAttributes[indexPath]
+    }
+    
+    
+    // MARK: For SupplementaryViewOfKind
+    
+    public override func layoutAttributesForSupplementaryView(ofKind elementKind: String, at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
+        
+        switch elementKind {
+        case UICollectionView.elementKindSectionHeader:
+            return sectionHeadersAttributes[indexPath]
+        default:
+            return nil
+        }
+        
+    }
+    
+    
+    // MARK: - Utility methods
+    
+    // MARK: SectionHeaders Attributes methods
+    
+    private func getSectionHeadersAttributes() -> [IndexPath : UICollectionViewLayoutAttributes] {
+        
+        func attributeForSectionHeader(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes {
+            
+            func size() -> CGSize {
+                return headerSize(forSection: indexPath.section)
+            }
+            
+            //
+            func position() -> CGPoint {
+                
+                if let itemsCount = collectionView?.numberOfItems(inSection: indexPath.section),
+                    let firstItemAttributes = layoutAttributesForItem(at: indexPath),
+                    let lastItemAttributes = layoutAttributesForItem(at: IndexPath(row: itemsCount - 1, section: indexPath.section)) {
+                    let safeAreaInsets: UIEdgeInsets = { if #available(iOS 11.0, *) { return collectionView!.safeAreaInsets } else { return .zero } }()
+                    let edgeX = collectionView!.contentOffset.x + collectionView!.contentInset.left + safeAreaInsets.left
+                    let xByLeftBoundary = max(edgeX, firstItemAttributes.frame.minX)
+                    //
+                    let width = size().width
+                    let xByRightBoundary = lastItemAttributes.frame.maxX - width
+                    let x = min(xByLeftBoundary,xByRightBoundary)
+                    return CGPoint(x: x, y: 0)
+                } else {
+                    return CGPoint(x: inset(ForSection: indexPath.section).left, y: 0)
+                }
+                
+            }
+            
+            //
+            let attribute = UICollectionViewLayoutAttributes(forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, with: indexPath)
+            attribute.frame = CGRect(origin: position(), size: size())
+            
+            return attribute
+            
+        }
+        
+        //
+        guard let collectionView = collectionView else {
+            return [:]
+        }
+        
+        let sectionCount = collectionView.numberOfSections
+        guard sectionCount > 0 else {
+            return [:]
+        }
+        
+        var attributes = [IndexPath : UICollectionViewLayoutAttributes]()
+        for section in 0..<sectionCount {
+            let indexPath = IndexPath(row: 0, section: section)
+            attributes[indexPath] = attributeForSectionHeader(at: indexPath)
+        }
+        
+        return attributes
+    }
+    
+    
+    // MARK: - Invalidating layout methods
+    
+    public override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
+        return true
+    }
+    
+    public override func invalidationContext(forBoundsChange newBounds: CGRect) -> UICollectionViewLayoutInvalidationContext {
+        
+        func isSizeChanged() -> Bool {
+            let oldBounds = collectionView?.bounds ?? .zero
+            return oldBounds.size != newBounds.size
+        }
+        
+        func headersIndexPaths() -> [IndexPath] {
+            return Array(sectionHeadersAttributes.keys)
+        }
+        
+        //
+        let context = super.invalidationContext(forBoundsChange: newBounds)
+        if !isSizeChanged() {
+            context.invalidateSupplementaryElements(ofKind: UICollectionView.elementKindSectionHeader, at: headersIndexPaths())
+        }
+        return context
+    }
+    
+    
+    // MARK: - Utility methods
+    
+    private func itemSize(for indexPath: IndexPath) -> CGSize {
+        guard let collectionView = collectionView,
+            let delegate = collectionView.delegate as? HorizontalFloatingHeaderLayoutDelegate else {
+                return CGSize.zero
+        }
+        
+        return delegate.collectionView(collectionView, horizontalFloatingHeaderItemSizeAt: indexPath)
+    }
+    
+    private func headerSize(forSection section: Int) -> CGSize {
+        guard let collectionView = collectionView,
+            let delegate = collectionView.delegate as? HorizontalFloatingHeaderLayoutDelegate,
+            section >= 0 else {
+                return CGSize.zero
+        }
+        
+        return delegate.collectionView(collectionView, horizontalFloatingHeaderSizeAt: section)
+    }
+    
+    private func inset(ForSection section: Int) -> UIEdgeInsets {
+        let defaultValue = UIEdgeInsets.zero
+        guard let collectionView = collectionView,
+            let delegate = collectionView.delegate as? HorizontalFloatingHeaderLayoutDelegate,
+            section >= 0 else {
+                return defaultValue
+        }
+        
+        return delegate.collectionView?(collectionView, horizontalFloatingHeaderSectionInsetAt: section) ?? defaultValue
+    }
+    
+    private func columnSpacing(forSection section:Int) -> CGFloat {
+        let defaultValue: CGFloat = 0.0
+        guard let collectionView = collectionView,
+            let delegate = collectionView.delegate as? HorizontalFloatingHeaderLayoutDelegate,
+            section >= 0 else {
+                return defaultValue
+        }
+        
+        return delegate.collectionView?(collectionView, horizontalFloatingHeaderColumnSpacingForSectionAt: section) ?? defaultValue
+    }
+    
+    private func itemSpacing(forSection section: Int) -> CGFloat {
+        let defaultValue:CGFloat = 0.0
+        guard let collectionView = collectionView,
+            let delegate = collectionView.delegate as? HorizontalFloatingHeaderLayoutDelegate,
+            section >= 0 else {
+                return defaultValue
+        }
+        
+        return delegate.collectionView?(collectionView, horizontalFloatingHeaderItemSpacingForSectionAt: section) ?? defaultValue
+    }
+    
+    private func availableHeight(atSection section: Int) -> CGFloat {
+        
+        // Ensure we have a collection view and the section is positive
+        guard let collectionView = collectionView, section >= 0 else { return 0.0 }
+        
+        func totalInset() -> CGFloat {
+            let sectionInset = inset(ForSection: section)
+            let contentInset = collectionView.contentInset
+            return sectionInset.top + sectionInset.bottom + contentInset.top + contentInset.bottom
+        }
+        
+        return collectionView.bounds.height - totalInset()
+    }
+}

--- a/Sources/KeyboardKit/UIKit/Buttons/HFloatingHeaderButtonCollectionView.swift
+++ b/Sources/KeyboardKit/UIKit/Buttons/HFloatingHeaderButtonCollectionView.swift
@@ -1,0 +1,214 @@
+//
+//  CustomButtonRowCollectionView.swift
+//  KeyboardKitDemoKeyboard
+//
+//  Created by 于留传 on 2021/1/16.
+//
+
+import UIKit
+
+open class HFloatingHeaderButtonCollectionView: KeyboardCollectionView, HorizontalFloatingHeaderLayoutDelegate, UICollectionViewDelegate{
+    
+    // MARK: - Initialization
+    public init(
+        id: String = "HFloatingHeaderButtonCollectionView",
+        categoryActions: [(String, KeyboardActions)],
+        configuration: Configuration,
+        buttonCreator: @escaping KeyboardButtonCreator){
+        self.id = id
+        self.categoryActions = categoryActions
+        self.categorySectionAction = Self.createCategorySectionAction(for: categoryActions)
+        self.configuration = configuration
+        self.buttonCreator = buttonCreator
+        super.init(actions: []) // Unused
+        setup()
+    }
+    
+    public required init?(coder aDecoder: NSCoder) {
+        self.id = ""
+        self.categoryActions = []
+        self.categorySectionAction = []
+        self.configuration = .empty
+        self.buttonCreator = { _ in fatalError() }
+        super.init(coder: aDecoder)
+        setup()
+    }
+    
+    // MARK: - Setup
+    
+    func setup(){
+        dataSource = self
+        delegate = self
+        height = configuration.totalHeight
+        collectionViewLayout = HorizontalFloatingHeaderLayout()
+        register(UICollectionReusableView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: headerIdentifier)
+    }
+    
+    // MARK: - Types
+    public typealias KeyboardButtonCreator = (KeyboardAction) -> (UIView)
+    
+    public struct Configuration{
+        public init(headerSize: CGSize, itemSize: CGSize, rowsCount: Int, titleColor: UIColor?, titleFont: UIFont?,
+                    headerWidthToFitText: Bool?, itemFont: UIFont?, itemWidthToFitText: Bool?, edgeInsets: UIEdgeInsets?){
+            self.headerSize = headerSize
+            self.itemSize = itemSize
+            self.rowsCount = rowsCount
+            self.titleColor = titleColor ?? UIColor(white: 0.6, alpha: 1.0)
+            self.titleFont = titleFont ?? UIFont.boldSystemFont(ofSize: UIFont.labelFontSize)
+            self.headerWidthToFitText = headerWidthToFitText ?? false
+            self.itemFont = itemFont ?? UIFont.boldSystemFont(ofSize: UIFont.labelFontSize)
+            self.itemWidthToFitText = itemWidthToFitText ?? false
+            self.edgeInsets = edgeInsets ?? UIEdgeInsets.zero
+        }
+        
+        public let edgeInsets: UIEdgeInsets
+        
+        public let itemWidthToFitText: Bool
+        public let itemFont: UIFont
+        public let headerWidthToFitText: Bool
+        
+        public let titleColor: UIColor
+        public let titleFont: UIFont
+        
+        public let headerSize: CGSize
+        public let itemSize: CGSize
+        public let rowsCount: Int
+        
+        private let padding: CGFloat = 10
+        
+        public var totalHeight: CGFloat{
+            headerSize.height + itemSize.height * CGFloat(rowsCount) + padding * 2
+        }
+        
+        public static var empty: Configuration{
+            Configuration(headerSize: .zero, itemSize: .zero, rowsCount: 0, titleColor: nil, titleFont: nil, headerWidthToFitText: false, itemFont: nil, itemWidthToFitText: false, edgeInsets: .zero)
+        }
+    }
+    // MARK: - Properties
+    public let headerIdentifier = "Header"
+    
+    public let id: String
+    public let configuration: Configuration
+    public let categoryActions: [(String, KeyboardActions)]
+    private let categorySectionAction: [(String, Int, Int)]
+    private let buttonCreator: KeyboardButtonCreator
+    // MARK: - Category
+    
+    static func createCategorySectionAction(for categoryActions: [(String, KeyboardActions)]) -> [(String, Int, Int)] {
+        categoryActions.enumerated().map { (index: Int, arg1) -> (String, Int, Int) in
+            let (cat, actions) = arg1
+            return (cat, index, actions.count)
+        }
+    }
+    
+    // MARK: - UICollectionViewDataSource
+    // Number of Sections
+    open override func numberOfSections(in collectionView: UICollectionView) -> Int {
+        self.categorySectionAction.count
+    }
+
+    // Number of Items
+    open override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        guard let index = self.categorySectionAction.first(where: { $0.1 == section }) else { return 0 }
+        return index.2
+    }
+
+    // Cells
+    open override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = super.collectionView(collectionView, cellForItemAt: indexPath)
+        cell.subviews.forEach { $0.removeFromSuperview() }
+        let action = self.categoryActions[indexPath.section].1[indexPath.item]
+        cell.addSubview(self.buttonCreator(action), fill: true)
+        return cell
+    }
+    
+    // Headers
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        let cell = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: headerIdentifier, for: indexPath)
+        cell.subviews.forEach { $0.removeFromSuperview() }
+        let titleLabel = UILabel()
+        titleLabel.text = self.categoryActions[indexPath.section].0
+        titleLabel.textColor = configuration.titleColor
+        titleLabel.font = configuration.titleFont
+        cell.addSubview(titleLabel, fill: true)
+        return cell
+    }
+
+    // MARK: - HorizontalFloatingHeaderDelegate
+    
+    // Item Size
+    public func collectionView(_ collectionView: UICollectionView, horizontalFloatingHeaderItemSizeAt indexPath: IndexPath) -> CGSize {
+        
+        if !configuration.itemWidthToFitText{
+            return configuration.itemSize
+        }
+        
+        // Dynamic Item Width
+        let actionText: String? = {
+            let action = self.categoryActions[indexPath.section].1[indexPath.item]
+            switch action {
+                case .character(let text): return text
+                default:
+                    return nil
+            }
+        }()
+        
+        if let text = actionText{
+            let size = self.sizeToFitText(text: text, font: configuration.itemFont)
+            let width = size.width + configuration.edgeInsets.left + configuration.edgeInsets.right
+            return CGSize(width: width, height: configuration.itemSize.height)
+        }else{
+            // Use default size
+            return configuration.itemSize
+        }
+    }
+    
+    // Header Size
+    public func collectionView(_ collectionView: UICollectionView, horizontalFloatingHeaderSizeAt section: Int) -> CGSize {
+        if configuration.headerWidthToFitText{
+            let headerText:String = self.categoryActions[section].0
+            let size:CGSize = self.sizeToFitText(text: headerText, font: configuration.titleFont)
+            // `width + 1` to fix bugs, like 'FLAGS --> FLA...'
+            return CGSize(width: size.width + 1, height: configuration.headerSize.height)
+        }else{
+            return configuration.headerSize
+        }
+    }
+    
+    // Vertial Spacing: Spacing Between Vertial Items
+    public func collectionView(_ collectionView: UICollectionView, horizontalFloatingHeaderItemSpacingForSectionAt section: Int) -> CGFloat {
+        return 0.0
+    }
+    
+    // Horizontal Spacing: Spacing Between Horizontal Items
+    public func collectionView(_ collectionView: UICollectionView, horizontalFloatingHeaderColumnSpacingForSectionAt section: Int) -> CGFloat {
+        return 0.0
+    }
+    
+    // Section Insets
+    public func collectionView(_ collectionView: UICollectionView, horizontalFloatingHeaderSectionInsetAt section: Int) -> UIEdgeInsets {
+        switch section{
+        case 0:
+            return UIEdgeInsets(top: 8, left: 0, bottom: 0, right: 0)
+        default:
+            return UIEdgeInsets(top: 8, left: 8, bottom: 0, right: 0)
+        }
+    }
+    
+    // MARK: - Size Function
+    private func sizeToFitText(text: String, font: UIFont) -> CGSize{
+        return text.size(withAttributes: [.font: font])
+    }
+}
+
+public extension HFloatingHeaderButtonCollectionView{
+    @objc func moveToSection(bySection section: Int){
+        guard section <= self.categorySectionAction.count else { return }
+        self.scrollToItem(at: IndexPath(item: 0, section: section), at: .left, animated: true)
+    }
+    
+    @objc func moveToSection(byCategory category: String){
+        guard let index = self.categorySectionAction.first(where: { $0.0 == category }) else { return }
+        self.moveToSection(bySection: index.1)
+    }
+}


### PR DESCRIPTION
I squashed #175 into one commit.

- Amendments
  - Add HorizontalFloatingHeaderLayout
  - Add HFloatingHeaderButtonCollectionView
  - Add EnhancedEmojiKeyboard
  - Replace `EmojiKeyboard` with `EnhancedEmojiKeyboard` in ViewController
  
- Features
  - Slide left or right continuously in emoji keyboard
  - Auto-scroll to the first column of the tapped category when a category action is tapped
  - Fixed title size or auto-sized title width with fixed height
  - Title font and color are configurable
  - Fixed keyboard item size or auto-sized item width with fixed height
 
**Note**
This is designed not only for emoji keyboard, but also for universal use, e.g. a characters based keyboard with many many actions.